### PR TITLE
Adding space to new comment just before typing it on screen. (#6343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_
 
+## [0.6.16] - UNRELEASED
+### Added
+
+- Adding space to new comment just before typing it on screen
 
 ## [0.6.15] - UNRELEASED
 ### Added

--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -81,7 +81,7 @@ def comment_image(browser, username, comments, blacklist, logger, logfolder):
             comment_input = get_comment_input(browser)
             # below, an extra space is added to force
             # the input box to update the reactJS core
-            comment_to_be_sent = rand_comment
+            comment_to_be_sent = rand_comment + " "
 
             # wait, to avoid crash
             sleep(2)


### PR DESCRIPTION
* Adding space to new comment just before typing it on screen.

* Update CHANGELOG.md

Co-authored-by: Daniel Carvallo <elulcao@icloud.com>

<!-- Did you know that we have a Discord channel ? Join us: https://discord.gg/FDETsht -->
<!-- Is this a Feature Request ? Please, check out our Wiki first https://github.com/timgrossmann/InstaPy/wiki -->
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Do not include any personal data.

Fixes # (issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked my code and corrected any misspellings
- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project, `black -t py34`
- [ ] My changes generate no new warnings
